### PR TITLE
Dockerfile*: Add tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,10 @@ RUN yum -y update && \
     && yum clean all \
     && rm -rf /tmp/* /var/tmp/*
 
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+
 ENV JAVA_HOME=/etc/alternatives/jre
 
 ENV HADOOP_VERSION 3.1.1

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -77,6 +77,10 @@ RUN yum -y update && \
     && yum clean all \
     && rm -rf /tmp/* /var/tmp/*
 
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+
 ENV JAVA_HOME=/etc/alternatives/jre
 
 ENV HADOOP_VERSION 3.1.1

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -53,6 +53,7 @@ RUN yum -y update && \
         rsync \
         openssl \
         faq \
+        tini \
     && yum clean all \
     && rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Allows running the JVM as a non-PID 1 process, which handles signals
specially.