### PR TITLE
Dockerfile*: Make Java root truststore $JAVA_HOME/lib/security/cacerts writable by GID 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,8 +121,8 @@ RUN useradd hadoop -m -u 1002 -d $HADOOP_HOME
 # imagebuilder expects the directory to be created before VOLUME
 RUN mkdir -p /hadoop/dfs/data /hadoop/dfs/name
 # to allow running as non-root
-RUN chown -R 1002:0 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR && \
-    chmod -R 774 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd
+RUN chown -R 1002:0 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd $JAVA_HOME/lib/security/cacerts && \
+    chmod -R 774 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd $JAVA_HOME/lib/security/cacerts
 
 VOLUME /hadoop/dfs/data /hadoop/dfs/name
 

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -117,8 +117,8 @@ RUN useradd hadoop -m -u 1002 -d $HADOOP_HOME
 # imagebuilder expects the directory to be created before VOLUME
 RUN mkdir -p /hadoop/dfs/data /hadoop/dfs/name
 # to allow running as non-root
-RUN chown -R 1002:0 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR && \
-    chmod -R 774 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd
+RUN chown -R 1002:0 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd $JAVA_HOME/lib/security/cacerts && \
+    chmod -R 774 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd $JAVA_HOME/lib/security/cacerts
 
 VOLUME /hadoop/dfs/data /hadoop/dfs/name
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -110,8 +110,8 @@ RUN useradd hadoop -m -u 1002 -d $HADOOP_HOME
 # imagebuilder expects the directory to be created before VOLUME
 RUN mkdir -p /hadoop/dfs/data /hadoop/dfs/name
 # to allow running as non-root
-RUN chown -R 1002:0 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR && \
-    chmod -R 774 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd
+RUN chown -R 1002:0 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd $JAVA_HOME/lib/security/cacerts && \
+    chmod -R 774 $HADOOP_HOME /hadoop $HADOOP_CONF_DIR /etc/passwd $JAVA_HOME/lib/security/cacerts
 
 VOLUME /hadoop/dfs/data /hadoop/dfs/name
 


### PR DESCRIPTION
In openshift, a container's user gets GID 0 so this will allow our pod to add to it's truststore from a secret containing extra CA's to trust.