### PR TITLE
support s390x in mapreduce-client-nativetask

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
@@ -99,6 +99,8 @@ inline void simple_memcpy(void * dest, const void * src, size_t len) {
 inline uint32_t bswap(uint32_t val) {
 #ifdef __aarch64__
   __asm__("rev %w[dst], %w[src]" : [dst]"=r"(val) : [src]"r"(val));
+#elif defined(__s390x__)||(__s390__)
+  return  __builtin_bswap32(val);
 #else
   __asm__("bswap %0" : "=r" (val) : "0" (val));
 #endif
@@ -108,6 +110,8 @@ inline uint32_t bswap(uint32_t val) {
 inline uint64_t bswap64(uint64_t val) {
 #ifdef __aarch64__
   __asm__("rev %[dst], %[src]" : [dst]"=r"(val) : [src]"r"(val));
+#elif defined(__s390x__)||(__s390__)
+  return  __builtin_bswap64(val);
 #else
 #ifdef __X64
   __asm__("bswapq %0" : "=r" (val) : "0" (val));


### PR DESCRIPTION
convert to big-endian on IBM z(s390/s390x)

Signed-off-by: Huang Rui <bjhuangr@cn.ibm.com>