### PR TITLE
Forcefully create the cmake3 symbolic link.

### DIFF
--- a/opt_maven_install.sh
+++ b/opt_maven_install.sh
@@ -23,7 +23,7 @@ if [[ "$1" == "true" ]]; then
   export PATH=${PATH}:${M2_HOME}/bin
   popd
 
-  ln -s /usr/bin/cmake3 /usr/bin/cmake
+  ln -sf /usr/bin/cmake3 /usr/bin/cmake
   export CMAKE_C_COMPILER=gcc CMAKE_CXX_COMPILER=g++
 
   # Build hadoop


### PR DESCRIPTION
This was showing up in the recent Dockerfile.rhel failure logs:
```bash
+ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/apache-maven-3.3.9/bin
+ popd
+ ln -s /usr/bin/cmake3 /usr/bin/cmake
ln: failed to create symbolic link '/usr/bin/cmake': File exists
error: build error: running 'chmod u+x /tmp/opt_maven_inst...opt_maven_install.sh $OPENSHIFT_CI' failed with exit code 1
```

If this symbolic link already exists, we can either remove the old symbolic link and recreate it, forcefully create it everytime, or remove the call entirely to create this symbolic link.