### PR TITLE
Bug 1872080: Prevent cmake symlink creation if file is present

### DIFF
--- a/opt_maven_install.sh
+++ b/opt_maven_install.sh
@@ -23,7 +23,7 @@ if [[ "$1" == "true" ]]; then
   export PATH=${PATH}:${M2_HOME}/bin
   popd
 
-  ln -s /usr/bin/cmake3 /usr/bin/cmake
+  test -e /usr/bin/cmake || ln -s /usr/bin/cmake3 /usr/bin/cmake
   export CMAKE_C_COMPILER=gcc CMAKE_CXX_COMPILER=g++
 
   # Build hadoop


### PR DESCRIPTION
Various build attempts have resulted in:
```
+ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/apache-maven-3.3.9/bin
+ popd
+ ln -s /usr/bin/cmake3 /usr/bin/cmake
ln: failed to create symbolic link '/usr/bin/cmake': File exists
```