### PR TITLE
Updating hadoop builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:rhel-7-release-openshift-4.6 AS build
+FROM registry.svc.ci.openshift.org/openshift/release:rhel-7-release-openshift-4.7 AS build
 # This FROM is RHEL7 based because the CI based hadoop build requires a precise
 # version of protobuf (2.5.0) which is unavilable on RHEL8. Downstream
 # production builds use RHEL8 for this builder image since protobuf 2.5.0 is not
@@ -11,7 +11,7 @@ WORKDIR /build
 COPY opt_maven_install.sh /tmp/
 RUN chmod u+x /tmp/opt_maven_install.sh && /tmp/opt_maven_install.sh $OPENSHIFT_CI
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
 RUN set -x; yum install --setopt=skip_missing_names_on_install=False -y \
         java-1.8.0-openjdk \


### PR DESCRIPTION
Updating hadoop builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/hadoop.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
