### PR TITLE
Bug 1913837: Updating hadoop builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,8 +1,10 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-4.7 AS build
+FROM registry.svc.ci.openshift.org/openshift/release:rhel-7-release-openshift-4.7 AS build
 # This FROM is RHEL7 based because the CI based hadoop build requires a precise
 # version of protobuf (2.5.0) which is unavilable on RHEL8. Downstream
 # production builds use RHEL8 for this builder image since protobuf 2.5.0 is not
 # required and ARM builds require RHEL8.
+# Note(tflannag): We need to use the registry.svc.ci registry as this image doesn't
+# exist in the registry.ci registry.
 
 RUN mkdir /build
 COPY . /build

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:rhel-7-release-openshift-4.6 AS build
+FROM registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-4.7 AS build
 # This FROM is RHEL7 based because the CI based hadoop build requires a precise
 # version of protobuf (2.5.0) which is unavilable on RHEL8. Downstream
 # production builds use RHEL8 for this builder image since protobuf 2.5.0 is not
@@ -11,7 +11,7 @@ WORKDIR /build
 COPY opt_maven_install.sh /tmp/
 RUN chmod u+x /tmp/opt_maven_install.sh && /tmp/opt_maven_install.sh $OPENSHIFT_CI
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 
 RUN set -x; yum install --setopt=skip_missing_names_on_install=False -y \
         java-1.8.0-openjdk \


### PR DESCRIPTION
Updating hadoop builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/8435904d3420debc55e605ba445ab647db4395c6/images/hadoop.yml

If you have any questions about this pull request, please reach out to @art-team in the #aos-art coreos slack channel.