### PR TITLE
Bug 1913837: Fix the path to the GCS connector jar

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -43,7 +43,7 @@ ENV PATH=$HADOOP_HOME/bin:$PATH
 
 COPY --from=build /build/hadoop-dist/target/hadoop-$HADOOP_VERSION $HADOOP_HOME
 COPY --from=build /build/jmx_prometheus_javaagent.jar $PROMETHEUS_JMX_EXPORTER
-COPY --from=build /build/gcs-connector-hadoop3-shaded.jar $HADOOP_HOME/share/hadoop/tools/lib/gcs-connector-hadoop3-shaded.jar
+COPY --from=build /build/gcs-connector-hadoop3-2.0.0-RC2-shaded.jar $HADOOP_HOME/share/hadoop/tools/lib/gcs-connector-hadoop3-shaded.jar
 WORKDIR $HADOOP_HOME
 
 # remove unnecessary doc/src files


### PR DESCRIPTION
Normalize the GCS connector JAR location as there was some inconsistency between the destination paths in the container for the CI and ART images.