### PR TITLE
Dockerfile: Print out all Guava JARs in the HADOOP classpath

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -58,6 +58,8 @@ RUN rm -rf ${HADOOP_HOME}/share/doc \
 
 RUN ln -s $HADOOP_HOME/etc/hadoop $HADOOP_CONF_DIR
 RUN mkdir -p $HADOOP_LOG_DIR
+# Debug artifact
+RUN find /opt/ -name '*guava-*.jar'
 
 # https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html
 # Java caches dns results forever, don't cache dns results forever:
@@ -80,4 +82,4 @@ USER 1002
 LABEL io.k8s.display-name="OpenShift Hadoop" \
       io.k8s.description="This is an image used by operator-metering to to install and run HDFS." \
       io.openshift.tags="openshift" \
-      maintainer="AOS Operator Metering <sd-operator-metering@redhat.com>"
+      maintainer="<metering-team@redhat.com>"


### PR DESCRIPTION
Update the Dockerfile.rhel and add a debug artifact that prints out the
version for any Guava JARs that may be in the configured classpath.

We're seeing a mismatch between the Hive and Hadoop Guava versions in
4.8 after that botched bump to Hadoop 3.1.4.