### PR TITLE
[release-4.7] Dockerfile: Avoid hardcoding the JAR names that contain the JMSAppender class

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -58,8 +58,7 @@ RUN rm -rf ${HADOOP_HOME}/share/doc \
     && find ${HADOOP_HOME}/share/hadoop -name *test*.jar | xargs rm -rf
 
 # remove JMSAppender class from built jars
-RUN zip -d share/hadoop/common/lib/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class
-RUN zip -d share/hadoop/hdfs/lib/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class
+RUN find share/ -name '*.jar' -type f -print0 | xargs -0 grep JMSAppender.class | awk '{print $3}' | xargs -L 1 -I {} /bin/bash -c 'zip -q -d '{}' org/apache/log4j/net/JMSAppender.class'
 
 RUN ln -s $HADOOP_HOME/etc/hadoop $HADOOP_CONF_DIR
 RUN mkdir -p $HADOOP_LOG_DIR


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>
